### PR TITLE
Fix: Gazette search no longer appears to work on plain ol' HTTP

### DIFF
--- a/config.py
+++ b/config.py
@@ -2,7 +2,7 @@
 PERSIST_DB = "persist.sqlite3"
 
 # URL items
-GAZETTE_BASE_URL = "http://www.gazette.gov.mv/"
+GAZETTE_BASE_URL = "https://www.gazette.gov.mv/"
 IULAAN_SEARCH_URL = "iulaan/search/"
 
 # Value Defaults


### PR DESCRIPTION
It looks like the reason the bot has been spamming is because search on Gazette is broken without SSL.

Form-data gets completely ignored on http 🤔